### PR TITLE
Add Interest Feature

### DIFF
--- a/BackEnd/LinkUp.Application/DTos/Interests/CreateUpdateInterestDto.cs
+++ b/BackEnd/LinkUp.Application/DTos/Interests/CreateUpdateInterestDto.cs
@@ -1,0 +1,3 @@
+namespace LinkUp.Application.DTos.Interests;
+
+public sealed record CreateUpdateInterestDto(string? Name);

--- a/BackEnd/LinkUp.Application/DTos/Interests/InterestDto.cs
+++ b/BackEnd/LinkUp.Application/DTos/Interests/InterestDto.cs
@@ -1,0 +1,8 @@
+namespace LinkUp.Application.DTos.Interests;
+
+public sealed record InterestDto(
+    Guid? InterestId,
+    string? Name,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt
+);

--- a/BackEnd/LinkUp.Application/Interfaces/Repository/IInterestRepository.cs
+++ b/BackEnd/LinkUp.Application/Interfaces/Repository/IInterestRepository.cs
@@ -1,5 +1,9 @@
+using LinkUp.Application.Pagination;
 using LinkUp.Domain.Models;
 
 namespace LinkUp.Application.Interfaces.Repository;
 
-public interface IInterestRepository : IGenericRepository<Interest>;
+public interface IInterestRepository : IGenericRepository<Interest>
+{
+    Task<PagedResult<Interest>> GetInterestsAsync(int page, int pageSize, CancellationToken cancellationToken);
+}

--- a/BackEnd/LinkUp.Application/Interfaces/Services/IInterestService.cs
+++ b/BackEnd/LinkUp.Application/Interfaces/Services/IInterestService.cs
@@ -1,0 +1,6 @@
+using LinkUp.Application.DTos.Interests;
+using LinkUp.Application.Interfaces.Base;
+
+namespace LinkUp.Application.Interfaces.Services;
+
+public interface IInterestService : IGenericService<CreateUpdateInterestDto, CreateUpdateInterestDto, InterestDto>;

--- a/BackEnd/LinkUp.Application/Mappers/InterestMapper.cs
+++ b/BackEnd/LinkUp.Application/Mappers/InterestMapper.cs
@@ -1,0 +1,28 @@
+using LinkUp.Application.DTos.Interests;
+using LinkUp.Domain.Models;
+
+namespace LinkUp.Application.Mappers;
+
+public static class InterestMapper
+{
+    public static InterestDto ToDto(Interest interest)
+    {
+        return new InterestDto(
+            InterestId: interest.Id,
+            Name: interest.Name,
+            CreatedAt: interest.CreatedAt,
+            UpdatedAt: interest.UpdatedAt
+        );
+    }
+
+    public static Interest ToEntity(CreateUpdateInterestDto createUpdateInterestDto)
+    {
+        return new Interest
+        {
+            Id = Guid.NewGuid(),
+            Name = createUpdateInterestDto.Name,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+    }
+}

--- a/BackEnd/LinkUp.Application/Services/InterestService.cs
+++ b/BackEnd/LinkUp.Application/Services/InterestService.cs
@@ -1,0 +1,132 @@
+using LinkUp.Application.DTos.Interests;
+using LinkUp.Application.Helpers;
+using LinkUp.Application.Interfaces.Repository;
+using LinkUp.Application.Interfaces.Services;
+using LinkUp.Application.Mappers;
+using LinkUp.Application.Pagination;
+using LinkUp.Application.Utils;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace LinkUp.Application.Services;
+
+public class InterestService(
+    ILogger<InterestService> logger,
+    IInterestRepository interestRepository,
+    IDistributedCache cache
+) : IInterestService
+{
+    public async Task<ResultT<InterestDto>> CreateAsync(CreateUpdateInterestDto entity,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(entity.Name))
+        {
+            logger.LogWarning("Name is empty.");
+
+            return ResultT<InterestDto>.Failure(Error.Failure("400", "Name is empty."));
+        }
+
+        if (await interestRepository.ValidateAsync(i => i.Name == entity.Name, cancellationToken))
+        {
+            logger.LogWarning("Interest with name {Name} already exists.", entity.Name);
+
+            return ResultT<InterestDto>.Failure(Error.Failure("400", "Interest with name already exists."));
+        }
+
+        var interest = InterestMapper.ToEntity(entity);
+
+        await interestRepository.CreateAsync(interest, cancellationToken);
+
+        logger.LogInformation("Interest '{InterestName}' created successfully with ID {InterestId}.",
+            interest.Name, interest.Id);
+
+        return ResultT<InterestDto>.Success(InterestMapper.ToDto(interest));
+    }
+
+
+    public async Task<Result> UpdateAsync(Guid id, CreateUpdateInterestDto entity, CancellationToken cancellationToken)
+    {
+        var interest = await EntityHelper.GetEntityByIdAsync(
+            interestId => interestRepository.GetByIdAsync(interestId, cancellationToken),
+            id,
+            "Interest",
+            logger
+        );
+
+        if (!interest.IsSuccess) return Result.Failure(interest.Error!);
+
+        interest.Value.Name = entity.Name;
+        interest.Value.UpdatedAt = DateTime.UtcNow;
+
+        await interestRepository.UpdateAsync(interest.Value, cancellationToken);
+
+        logger.LogInformation("Interest updated successfully.");
+
+        return Result.Success();
+    }
+
+    public async Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var interest = await EntityHelper.GetEntityByIdAsync(
+            interestId => interestRepository.GetByIdAsync(interestId, cancellationToken),
+            id,
+            "Interest",
+            logger
+        );
+
+        if (!interest.IsSuccess) return Result.Failure(interest.Error!);
+
+        await interestRepository.DeleteAsync(interest.Value, cancellationToken);
+
+        logger.LogInformation("Interest deleted successfully.");
+
+        return Result.Success();
+    }
+
+    public async Task<ResultT<InterestDto>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var interest = await EntityHelper.GetEntityByIdAsync(
+            interestId => interestRepository.GetByIdAsync(interestId, cancellationToken),
+            id,
+            "Interest",
+            logger
+        );
+
+        if (!interest.IsSuccess) return ResultT<InterestDto>.Failure(interest.Error!);
+
+        logger.LogInformation("Interest found successfully.");
+
+        return ResultT<InterestDto>.Success(InterestMapper.ToDto(interest.Value));
+    }
+
+    public async Task<ResultT<PagedResult<InterestDto>>> GetPagedAsync(int page, int size,
+        CancellationToken cancellationToken)
+    {
+        var validationPagination = EntityHelper.ValidatePagination<InterestDto>(page, size, logger);
+
+        if (!validationPagination.IsSuccess)
+            return ResultT<PagedResult<InterestDto>>.Failure(validationPagination.Error!);
+
+        string key = $"get-paged-interest-{page}-{size}";
+
+        var result = await cache.GetOrCreateAsync(key, async () =>
+        {
+            var paged = await interestRepository.GetInterestsAsync(page, size, cancellationToken);
+
+            var pagedDto = paged.Items.Select(InterestMapper.ToDto).ToList();
+
+            return new PagedResult<InterestDto>(pagedDto, paged.TotalItems, page, size);
+        }, cancellationToken: cancellationToken);
+
+        if (!result.Items.Any())
+        {
+            logger.LogWarning("No interests found.");
+
+            return ResultT<PagedResult<InterestDto>>.Failure(Error.Failure("404", "No interests found."));
+        }
+
+        logger.LogInformation("Interests found successfully.");
+
+        return ResultT<PagedResult<InterestDto>>.Success(result);
+    }
+}

--- a/BackEnd/LinkUp.Infrastructure.Persistence/Repository/InterestRepository.cs
+++ b/BackEnd/LinkUp.Infrastructure.Persistence/Repository/InterestRepository.cs
@@ -1,10 +1,24 @@
 using LinkUp.Application.Interfaces.Repository;
+using LinkUp.Application.Pagination;
 using LinkUp.Domain.Models;
 using LinkUp.Infrastructure.Persistence.Context;
+using Microsoft.EntityFrameworkCore;
 
 namespace LinkUp.Infrastructure.Persistence.Repository;
 
-public class InterestRepository(LinkUpDbContext context): GenericRepository<Interest>(context), IInterestRepository
+public class InterestRepository(LinkUpDbContext context) : GenericRepository<Interest>(context), IInterestRepository
 {
-    
+    public async Task<PagedResult<Interest>> GetInterestsAsync(int page, int pageSize,
+        CancellationToken cancellationToken)
+    {
+        var total = await Context.Set<Interest>().AsNoTracking().CountAsync(cancellationToken);
+        
+        var query = await Context.Set<Interest>()
+            .AsNoTracking()
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken);
+        
+        return new PagedResult<Interest>(query, total, page, pageSize);
+    }
 }

--- a/BackEnd/LinkUp.Presentation.API/Controllers/V1/InterestController.cs
+++ b/BackEnd/LinkUp.Presentation.API/Controllers/V1/InterestController.cs
@@ -1,0 +1,85 @@
+using Asp.Versioning;
+using LinkUp.Application.DTos.Interests;
+using LinkUp.Application.Interfaces.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace LinkUp.Presentation.API.Controllers;
+
+[ApiController]
+[ApiVersion("1.0")]
+[Route("api/v{version:apiVersion}/interests")]
+public class InterestController(IInterestService service) : ControllerBase
+{
+    /// <summary>
+    /// Creates a new interest.
+    /// </summary>
+    [HttpPost]
+    public async Task<IActionResult> Create(
+        [FromBody] CreateUpdateInterestDto dto,
+        CancellationToken cancellationToken)
+    {
+        var result = await service.CreateAsync(dto, cancellationToken);
+
+        if (!result.IsSuccess) return BadRequest(result.Error);
+
+        return CreatedAtAction(nameof(GetById), new { id = result.Value.InterestId }, result.Value);
+    }
+
+    /// <summary>
+    /// Updates an existing interest by id.
+    /// </summary>
+    [HttpPut("{id:guid}")]
+    public async Task<IActionResult> Update(
+        Guid id,
+        [FromBody] CreateUpdateInterestDto dto,
+        CancellationToken cancellationToken)
+    {
+        var result = await service.UpdateAsync(id, dto, cancellationToken);
+
+        if (!result.IsSuccess) return BadRequest(result.Error);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Deletes an interest by id.
+    /// </summary>
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> Delete(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await service.DeleteAsync(id, cancellationToken);
+
+        if (!result.IsSuccess) return NotFound(result.Error);
+
+        return NoContent();
+    }
+
+    /// <summary>
+    /// Gets an interest by id.
+    /// </summary>
+    [HttpGet("{id:guid}")]
+    public async Task<IActionResult> GetById(Guid id, CancellationToken cancellationToken)
+    {
+        var result = await service.GetByIdAsync(id, cancellationToken);
+
+        if (!result.IsSuccess) return NotFound(result.Error);
+
+        return Ok(result.Value);
+    }
+
+    /// <summary>
+    /// Gets a paged list of interests.
+    /// </summary>
+    [HttpGet]
+    public async Task<IActionResult> GetPaged(
+        [FromQuery] int page = 1,
+        [FromQuery] int size = 10,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await service.GetPagedAsync(page, size, cancellationToken);
+
+        if (!result.IsSuccess) return NotFound(result.Error);
+
+        return Ok(result.Value);
+    }
+}


### PR DESCRIPTION
## Description
This PR introduces the **Interest** functionality, including DTOs, service with full CRUD operations, mapper, controller, and pagination support in the repository.

## Changes Included
- **Repository**
  - Added pagination method for `InterestRepository`.
- **DTOs**
  - Added `InterestDto` and `CreateUpdateInterestDto`.
- **Service**
  - Implemented `InterestService` with full CRUD:
    - `CreateAsync`
    - `UpdateAsync`
    - `DeleteAsync`
    - `GetByIdAsync`
    - `GetPagedAsync` (with cache support)
- **Mapper**
  - Added `InterestMapper` to map between entities and DTOs.
- **Controller**
  - Added `InterestController` with RESTful endpoints.

## Commits
- `feat: add pagination method for Interest repository`
- `feat: add interest dto`
- `feat: implement Interest service with full CRUD operations`
- `feat: add InterestMapper and InterestController`

## Checklist
- [x] Added repository pagination method
- [x] Added Interest DTOs
- [x] Implemented Interest service with CRUD
- [x] Added Mapper for Interest entity/DTO conversion
- [x] Added Controller with endpoints for Interest
