### PR TITLE
Introduce Shared Layer with Admin Service and Cloudinary Integration

### DIFF
--- a/BackEnd/LinkUp.Application/DTos/Admin/AdminDto.cs
+++ b/BackEnd/LinkUp.Application/DTos/Admin/AdminDto.cs
@@ -1,0 +1,13 @@
+using LinkUp.Domain.Enum;
+
+namespace LinkUp.Application.DTos.Admin;
+
+public record AdminDto(
+    Guid Id,
+    string? FirstName,
+    string? LastName,
+    string? UserName,
+    string? Email,
+    string? ProfilePhoto,
+    AdminStatus Status
+    );

--- a/BackEnd/LinkUp.Application/DTos/Admin/CreateAdminDto.cs
+++ b/BackEnd/LinkUp.Application/DTos/Admin/CreateAdminDto.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Http;
+
+namespace LinkUp.Application.DTos.Admin;
+
+public record CreateAdminDto(
+    string? FirstName,
+    string? LastName,
+    string? UserName,
+    string? Email,
+    string? Password,
+    IFormFile? ProfilePhoto
+    );

--- a/BackEnd/LinkUp.Application/DTos/Admin/UpdateAdminDto.cs
+++ b/BackEnd/LinkUp.Application/DTos/Admin/UpdateAdminDto.cs
@@ -1,0 +1,7 @@
+namespace LinkUp.Application.DTos.Admin;
+
+public record UpdateAdminDto(
+    string? FirstName,
+    string? LastName,
+    string? ProfilePhoto
+    );

--- a/BackEnd/LinkUp.Application/Interfaces/Repository/IAdminRepository.cs
+++ b/BackEnd/LinkUp.Application/Interfaces/Repository/IAdminRepository.cs
@@ -61,4 +61,9 @@ public interface IAdminRepository : IGenericRepository<Admin>
     /// <param name="userId">The ID of the user to unban.</param>
     /// <param name="cancellationToken">Token to cancel the operation.</param>
     Task UnbanUserAsync(Guid userId, CancellationToken cancellationToken);
+
+    Task<bool> EmailExistAsync(string email, CancellationToken cancellationToken);
+    
+    Task<bool> UserNameExistAsync(string userName, CancellationToken cancellationToken);
+
 }

--- a/BackEnd/LinkUp.Application/Interfaces/Services/IAdminService.cs
+++ b/BackEnd/LinkUp.Application/Interfaces/Services/IAdminService.cs
@@ -1,0 +1,12 @@
+using LinkUp.Application.DTos.Admin;
+using LinkUp.Application.Interfaces.Base;
+using LinkUp.Application.Pagination;
+using LinkUp.Application.Utils;
+
+namespace LinkUp.Application.Interfaces.Services;
+
+public interface IAdminService: IGenericService<CreateAdminDto, UpdateAdminDto, AdminDto>
+{
+    Task<ResultT<string>> BanUserAsync(Guid userId,CancellationToken cancellationToken);
+    Task<ResultT<string>> UnbanUserAsync(Guid userId, CancellationToken cancellationToken);
+}

--- a/BackEnd/LinkUp.Application/Interfaces/Services/ICloudinaryService.cs
+++ b/BackEnd/LinkUp.Application/Interfaces/Services/ICloudinaryService.cs
@@ -1,0 +1,7 @@
+namespace LinkUp.Application.Interfaces.Services;
+
+public interface ICloudinaryService
+{
+    Task<string> UploadImageAsync(Stream archive, string imageName, CancellationToken cancellationToken);
+
+}

--- a/BackEnd/LinkUp.Application/Mappers/AdminMapper.cs
+++ b/BackEnd/LinkUp.Application/Mappers/AdminMapper.cs
@@ -1,0 +1,42 @@
+using LinkUp.Application.DTos.Admin;
+using LinkUp.Domain.Enum;
+using LinkUp.Domain.Models;
+
+namespace LinkUp.Application.Mappers;
+
+public static class AdminMapper
+{
+    public static AdminDto ToDto(this Admin admin)
+    {
+        return new AdminDto(
+            Id: admin.Id,
+            FirstName: admin.FirstName,
+            LastName: admin.LastName,
+            UserName: admin.UserName,
+            Email: admin.Email,
+            ProfilePhoto: admin.ProfilePhoto,
+            Status: admin.Status
+        );
+    }
+    
+    public static Admin ToEntity(this CreateAdminDto dto)
+    {
+        return new Admin
+        {
+            FirstName = dto.FirstName,
+            LastName = dto.LastName,
+            UserName = dto.UserName,
+            Email = dto.Email,
+            Password = BCrypt.Net.BCrypt.HashPassword(dto.Password),
+            Status = AdminStatus.Active,
+            ConfirmedAccount = true
+        };
+    }
+    
+    public static void UpdateEntity(this Admin admin, UpdateAdminDto dto)
+    {
+        admin.FirstName = dto.FirstName;
+        admin.LastName = dto.LastName;
+        admin.ProfilePhoto = dto.ProfilePhoto;
+    }
+}

--- a/BackEnd/LinkUp.Application/Services/AdminService.cs
+++ b/BackEnd/LinkUp.Application/Services/AdminService.cs
@@ -1,0 +1,136 @@
+using LinkUp.Application.DTos.Admin;
+using LinkUp.Application.Helpers;
+using LinkUp.Application.Interfaces.Repository;
+using LinkUp.Application.Interfaces.Services;
+using LinkUp.Application.Mappers;
+using LinkUp.Application.Pagination;
+using LinkUp.Application.Utils;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
+
+namespace LinkUp.Application.Services;
+
+public class AdminService(
+    ILogger<AdminService> logger,
+    IDistributedCache cache,
+    IAdminRepository adminRepository,
+    IUserRepository userRepository,
+    ICloudinaryService cloudinaryService
+    ): IAdminService
+{
+    public async Task<ResultT<AdminDto>> CreateAsync(CreateAdminDto entity, CancellationToken cancellationToken)
+    {
+        var adminExist = await adminRepository.EmailExistAsync(entity.Email ?? String.Empty, cancellationToken);
+        if (adminExist)
+        {
+            logger.LogWarning("Email already exist");
+            return ResultT<AdminDto>.Failure(Error.Conflict("409","Email already exist"));
+        }
+
+        var userNameExist = await adminRepository.UserNameExistAsync(entity.UserName ?? String.Empty, cancellationToken);
+        if (userNameExist)
+        {
+            logger.LogWarning("UserName already exist");
+            return ResultT<AdminDto>.Failure(Error.Failure("409","UserName already exist"));
+        }
+        
+        string profilePhotoUrl = "";
+        if (entity.ProfilePhoto is not null)
+        {
+            using var stream = entity.ProfilePhoto.OpenReadStream();
+            profilePhotoUrl = await cloudinaryService.UploadImageAsync(
+                stream,
+                entity.ProfilePhoto.FileName,
+                cancellationToken
+            );
+            logger.LogInformation("Profile photo uploaded for user {UserName}.", entity.UserName);
+        }
+        
+        var admin = AdminMapper.ToEntity(entity);
+        admin.ProfilePhoto = profilePhotoUrl;
+        
+        await adminRepository.CreateAsync(admin, cancellationToken);
+        logger.LogInformation("Created admin");
+        
+        return ResultT<AdminDto>.Success(AdminMapper.ToDto(admin));
+    }
+
+    public async Task<Result> UpdateAsync(Guid id, UpdateAdminDto entity, CancellationToken cancellationToken)
+    {
+        var adminResult = await EntityHelper.GetEntityByIdAsync(
+            adminEntity => adminRepository.GetByIdAsync(adminEntity, cancellationToken),
+            id,
+            "Admin",
+            logger
+        );
+
+        if (!adminResult.IsSuccess) 
+            return Result.Failure(adminResult.Error!);
+
+        var admin = adminResult.Value!; 
+
+        AdminMapper.UpdateEntity(admin, entity);
+
+        await adminRepository.UpdateAsync(admin, cancellationToken);
+
+        return Result.Success();
+    }
+
+
+    public async Task<Result> DeleteAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var admin = await EntityHelper.GetEntityByIdAsync(
+            adminEntity => adminRepository.GetByIdAsync(adminEntity, cancellationToken), id, "Admin", logger);
+
+        if (!admin.IsSuccess) return Result.Failure(admin.Error!);
+
+        await adminRepository.DeleteAsync(admin.Value, cancellationToken);
+        logger.LogWarning("Admin deleted");
+        
+        return Result.Success();
+    }
+
+    public async Task<ResultT<AdminDto>> GetByIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var adminExist = await EntityHelper.GetEntityByIdAsync(
+            adminEntity => adminRepository.GetByIdAsync(adminEntity, cancellationToken), id, "Admin", logger);
+
+        if(!adminExist.IsSuccess) return ResultT<AdminDto>.Failure(adminExist.Error!);
+
+        logger.LogInformation("Admin found");
+
+        return ResultT<AdminDto>.Success(AdminMapper.ToDto(adminExist.Value));
+    }
+
+    public async Task<ResultT<PagedResult<AdminDto>>> GetPagedAsync(int page, int size, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<ResultT<string>> BanUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var user = await EntityHelper.GetEntityByIdAsync(
+            userEntity => userRepository.GetByIdAsync(userEntity, cancellationToken), userId, "User", logger);
+
+        if (!user.IsSuccess) return ResultT<string>.Failure(user.Error!);
+        
+        await adminRepository.BanUserAsync(userId, cancellationToken);
+        logger.LogInformation("User banned");
+        
+        return ResultT<string>.Success("User banned successfully");
+        
+    }
+
+    public async Task<ResultT<string>> UnbanUserAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var user = await EntityHelper.GetEntityByIdAsync(
+            userEntity => userRepository.GetByIdAsync(userEntity, cancellationToken), userId, "User", logger);
+        
+        if (!user.IsSuccess) return ResultT<string>.Failure(user.Error!);
+        
+        await adminRepository.UnbanUserAsync(userId, cancellationToken);
+        logger.LogInformation("User unbanned");
+        
+        return ResultT<string>.Success("User unbanned successfully");
+    }
+}

--- a/BackEnd/LinkUp.Domain/Configuration/CloudinaryConfiguration.cs
+++ b/BackEnd/LinkUp.Domain/Configuration/CloudinaryConfiguration.cs
@@ -1,0 +1,7 @@
+namespace LinkUp.Domain.Configuration;
+
+public class CloudinaryConfiguration
+{
+    public string? CloudinaryUrl { get; set; }
+
+}

--- a/BackEnd/LinkUp.Domain/Models/Admin.cs
+++ b/BackEnd/LinkUp.Domain/Models/Admin.cs
@@ -20,6 +20,8 @@ public sealed class Admin : SoftDeletableEntity
     public DateTime? LastLoginAt { get; set; }
     
     public AdminStatus Status { get; set; } = AdminStatus.Active;
+    
+    public bool ConfirmedAccount { get; set; } = false;
 
     public ICollection<Post> Posts { get; set; } = new List<Post>();
 }

--- a/BackEnd/LinkUp.Infrastructure.Persistence/Context/LinkUpDbContext.cs
+++ b/BackEnd/LinkUp.Infrastructure.Persistence/Context/LinkUpDbContext.cs
@@ -291,6 +291,9 @@ public class LinkUpDbContext(DbContextOptions<LinkUpDbContext> dbContextOptions)
             admin.Property(a => a.Status)
                 .HasConversion<string>()
                 .HasDefaultValue(AdminStatus.Active);
+            
+            admin.Property(a => a.ConfirmedAccount)
+                .HasDefaultValue(false);
 
             admin.Property(a => a.CreatedAt)
                 .IsRequired()

--- a/BackEnd/LinkUp.Infrastructure.Persistence/Migrations/20250913232231_AddConfirmedAccount.Designer.cs
+++ b/BackEnd/LinkUp.Infrastructure.Persistence/Migrations/20250913232231_AddConfirmedAccount.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LinkUp.Infrastructure.Persistence.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LinkUp.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(LinkUpDbContext))]
-    partial class LinkUpDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250913232231_AddConfirmedAccount")]
+    partial class AddConfirmedAccount
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BackEnd/LinkUp.Infrastructure.Persistence/Migrations/20250913232231_AddConfirmedAccount.cs
+++ b/BackEnd/LinkUp.Infrastructure.Persistence/Migrations/20250913232231_AddConfirmedAccount.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LinkUp.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfirmedAccount : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "Deleted",
+                table: "RefreshTokens",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "RefreshTokens",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "Deleted",
+                table: "Codes",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "Codes",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "ConfirmedAccount",
+                table: "Admins",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "RefreshTokens");
+
+            migrationBuilder.DropColumn(
+                name: "Deleted",
+                table: "Codes");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "Codes");
+
+            migrationBuilder.DropColumn(
+                name: "ConfirmedAccount",
+                table: "Admins");
+        }
+    }
+}

--- a/BackEnd/LinkUp.Infrastructure.Persistence/Repository/AdminRepository.cs
+++ b/BackEnd/LinkUp.Infrastructure.Persistence/Repository/AdminRepository.cs
@@ -48,4 +48,7 @@ public class AdminRepository(LinkUpDbContext context): GenericRepository<Admin>(
 
     public async Task<bool> EmailExistAsync(string email, CancellationToken cancellationToken) =>
         await ValidateAsync(a => a.Email == email, cancellationToken);
+
+    public async Task<bool> UserNameExistAsync(string userName, CancellationToken cancellationToken) =>
+        await ValidateAsync(u => u.UserName == userName, cancellationToken);
 }

--- a/BackEnd/LinkUp.Infrastructure.Shared/DependencyInjection.cs
+++ b/BackEnd/LinkUp.Infrastructure.Shared/DependencyInjection.cs
@@ -1,0 +1,5 @@
+﻿namespace LinkUp.Infrastructure.Shared;
+
+public class DependencyInjection
+{
+}

--- a/BackEnd/LinkUp.Infrastructure.Shared/LinkUp.Infrastructure.Shared.csproj
+++ b/BackEnd/LinkUp.Infrastructure.Shared/LinkUp.Infrastructure.Shared.csproj
@@ -1,0 +1,26 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <PackageReference Include="CloudinaryDotNet" Version="1.27.7" />
+      <PackageReference Include="MailKit" Version="4.12.0" />
+      <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+      <PackageReference Include="Microsoft.AspNetCore.SignalR" Version="1.2.0" />
+      <PackageReference Include="Microsoft.Extensions.Options" Version="8.0.2" />
+      <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="8.0.0" />
+      <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.10.0" />
+      <PackageReference Include="MimeKit" Version="4.12.0" />
+      <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.10.0" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\LinkUp.Application\LinkUp.Application.csproj" />
+      <ProjectReference Include="..\LinkUp.Domain\LinkUp.Domain.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/BackEnd/LinkUp.Infrastructure.Shared/Services/CloudinaryService.cs
+++ b/BackEnd/LinkUp.Infrastructure.Shared/Services/CloudinaryService.cs
@@ -1,0 +1,26 @@
+using CloudinaryDotNet;
+using CloudinaryDotNet.Actions;
+using LinkUp.Application.Interfaces.Services;
+using Microsoft.Extensions.Options;
+
+namespace LinkUp.Infrastructure.Shared.Services;
+
+public sealed class CloudinaryService(IOptions<Domain.Configuration.CloudinaryConfiguration> cloudinaryOptions): ICloudinaryService
+{
+    private Domain.Configuration.CloudinaryConfiguration _cloudinaryConfiguration { get; } = cloudinaryOptions.Value;
+    
+
+    public async Task<string> UploadImageAsync(Stream archive, string imageName, CancellationToken cancellationToken)
+    {
+        var cloudinary = new Cloudinary(_cloudinaryConfiguration.CloudinaryUrl);
+        ImageUploadParams uploadImage = new()
+        {
+            File = new FileDescription(imageName, archive),
+            UseFilename = true,
+            UniqueFilename = false,
+            Overwrite = true
+        };
+        ImageUploadResult uploadResult = await cloudinary.UploadAsync(uploadImage, cancellationToken);
+        return uploadResult.SecureUrl.ToString();
+    }
+}

--- a/BackEnd/LinkUp.Presentation.API/LinkUp.Presentation.API.csproj
+++ b/BackEnd/LinkUp.Presentation.API/LinkUp.Presentation.API.csproj
@@ -23,6 +23,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\LinkUp.Infrastructure.Persistence\LinkUp.Infrastructure.Persistence.csproj" />
+      <ProjectReference Include="..\LinkUp.Infrastructure.Shared\LinkUp.Infrastructure.Shared.csproj" />
     </ItemGroup>
 
 </Project>

--- a/BackEnd/LinkUp.sln
+++ b/BackEnd/LinkUp.sln
@@ -18,6 +18,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Application", "Application"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkUp.Application", "LinkUp.Application\LinkUp.Application.csproj", "{0BBCF648-6CE2-44AC-A67D-3F1C94E52DD4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkUp.Infrastructure.Shared", "LinkUp.Infrastructure.Shared\LinkUp.Infrastructure.Shared.csproj", "{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,7 @@ Global
 		{3E03AEAF-AFD8-4915-A189-60FC12E977F6} = {AF8392AA-FA71-4588-A29E-1F47604B21D8}
 		{D143E13F-2C63-4295-8D04-C0B9ECF3ECD8} = {B0851C07-9CE2-4EF2-BDF6-F5167D0C003F}
 		{0BBCF648-6CE2-44AC-A67D-3F1C94E52DD4} = {D143E13F-2C63-4295-8D04-C0B9ECF3ECD8}
+		{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0} = {3DCBC7E6-A2F4-4CAF-A5BF-343C6D65AECB}
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{70048408-4D48-4DEF-BA6D-9088672414F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -50,5 +53,9 @@ Global
 		{0BBCF648-6CE2-44AC-A67D-3F1C94E52DD4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0BBCF648-6CE2-44AC-A67D-3F1C94E52DD4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0BBCF648-6CE2-44AC-A67D-3F1C94E52DD4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A3A77C7C-2D68-448A-819A-75BFCBB3F1F0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Overview
This PR introduces a new **Shared** layer (`LinkUp.Infrastructure.Shared`) and implements the foundational functionality for **Admin management** and **image handling**. It sets the groundwork for shared services across the application, improving modularity and maintainability.

## Key Features
- **Shared Layer**: Centralized services for reusable functionality.
- **AdminService**:
  - Create, update, delete admins.
  - Ban and unban users.
  - Validation for duplicate emails and usernames.
- **DTOs & Mappers**: `AdminDto`, `CreateAdminDto`, `UpdateAdminDto` and mapping utilities.
- **Cloudinary Integration**: Upload and manage admin profile images.
- **Interfaces**: `IAdminRepository`, `IAdminService`, `ICloudinaryService` to enforce contracts.
- **Configuration & DI**:
  - `CloudinaryConfiguration` for environment-specific settings.
  - Initial Dependency Injection setup for the Shared layer.
- **Project Updates**: Solution and project references updated to include the new Shared layer.

## Impact
This PR improves the overall structure and maintainability of the backend by introducing a shared layer and standardized admin operations, enabling easier future development and integration of shared services.
